### PR TITLE
remove double .github

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   compliance:
-    uses: OpenSource-Communities/.github/.github/workflows/compliance.yml@main
+    uses: OpenSource-Communities/.github/workflows/compliance.yml@main


### PR DESCRIPTION
I'm not sure, but we may not need the double .github here. 